### PR TITLE
add plain_fsm app in the 'applications' section of .app.src

### DIFF
--- a/src/hanoidb.app.src
+++ b/src/hanoidb.app.src
@@ -29,7 +29,8 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  plain_fsm
                  ]},
   {mod, {hanoidb_app, []}},
   {env, []}


### PR DESCRIPTION
plain_fsm must be started prior to hanoidb
